### PR TITLE
データ構造の修正およびノードダウン時の耐性のシミュレーションのための修正

### DIFF
--- a/chord_sim/chord_sim.py
+++ b/chord_sim/chord_sim.py
@@ -207,7 +207,7 @@ def do_put_on_random_node():
 
     if ChordNode.need_put_retry_data_id != -1:
         # 前回の呼び出し時に global_putが失敗しており、リトライが必要
-        
+
         # key と value の値は共通としているため、記録してあった value の値を key としても用いる
         kv_data = KeyValue(ChordNode.need_put_retry_data_value, ChordNode.need_put_retry_data_value)
         # data_id は乱数で求めるというインチキをしているため、記録してあったもので上書きする

--- a/chord_sim/chord_sim.py
+++ b/chord_sim/chord_sim.py
@@ -143,9 +143,9 @@ def do_stabilize_once_at_all_node():
 
     # 各リストはpopメソッドで要素を取り出して利用されていく
     # 同じノードは複数回利用されるため、その分コピーしておく（参照がコピーされるだけ）
-    shuffled_node_list_successor = random.sample(node_list, len(node_list))
+    shuffled_node_list_successor : List[ChordNode] = random.sample(node_list, len(node_list))
     shuffled_node_list_successor = shuffled_node_list_successor * gval.STABILIZE_SUCCESSOR_BATCH_TIMES
-    shuffled_node_list_ftable = random.sample(node_list, len(node_list))
+    shuffled_node_list_ftable : List[ChordNode] = random.sample(node_list, len(node_list))
     shuffled_node_list_ftable = shuffled_node_list_ftable * (gval.STABILIZE_FTABLE_BATCH_TIMES * gval.ID_SPACE_BITS)
 
     cur_node_num = len(node_list)
@@ -184,19 +184,21 @@ def do_stabilize_once_at_all_node():
             # 選択された処理を実行する
             if selected_operation == "successor":
                 node = shuffled_node_list_successor.pop()
-                node.stabilize_successor()
-                ChordUtil.dprint("do_stabilize_on_random_node__successor," + ChordUtil.gen_debug_str_of_node(node.node_info) + ","
-                                   + str(done_stabilize_successor_cnt))
+                if node.is_alive == True:
+                    node.stabilize_successor()
+                    ChordUtil.dprint("do_stabilize_on_random_node__successor," + ChordUtil.gen_debug_str_of_node(node.node_info) + ","
+                                       + str(done_stabilize_successor_cnt))
                 done_stabilize_successor_cnt += 1
             else: # "ftable"
                 # 1ノードの1エントリを更新する
                 # 更新するエントリのインデックスはこの関数の呼び出し時点の全ノード
                 # で共通に0からインクリメントされていく
                 node = shuffled_node_list_ftable.pop()
-                ChordUtil.dprint(
-                    "do_stabilize_on_random_node__ftable," + ChordUtil.gen_debug_str_of_node(node.node_info) + ","
-                    + str(cur_ftable_idx))
-                node.stabilize_finger_table(cur_ftable_idx)
+                if node.is_alive == True:
+                    ChordUtil.dprint(
+                        "do_stabilize_on_random_node__ftable," + ChordUtil.gen_debug_str_of_node(node.node_info) + ","
+                        + str(cur_ftable_idx))
+                    node.stabilize_finger_table(cur_ftable_idx)
                 done_stabilize_ftable_cnt += 1
 
                 if done_stabilize_ftable_cnt % cur_node_num == 0:

--- a/chord_sim/chord_sim.py
+++ b/chord_sim/chord_sim.py
@@ -44,7 +44,7 @@ def check_nodes_connectivity():
             cur_node_info = ChordUtil.get_node_by_address(cur_node_info.address_str).node_info.successor_info_list[0]
         except NodeIsDownedExceptiopn:
             print("")
-            ChordUtil.dprint("check_nodes_connectivity__succ, NODE_IS_DOWNED")
+            ChordUtil.dprint("check_nodes_connectivity__succ,NODE_IS_DOWNED")
             return
 
         if cur_node_info == None:
@@ -53,16 +53,20 @@ def check_nodes_connectivity():
         counter += 1
     print("")
 
-    # # 2ノード目が参加して以降をチェック対象とする
-    # # successorを辿って最初のノードに戻ってきているはずだが、そうなっていない場合は successorの
-    # # チェーン構造が正しく構成されていないことを意味するためエラーとして終了する
-    # if all_node_num >=2 and cur_node_info.node_id != start_node_info.node_id:
-    #     ChordUtil.dprint("check_nodes_connectivity_succ_err,chain does not include all node. all_node_num = "
-    #                      + str(all_node_num) + ","
-    #                      + ChordUtil.gen_debug_str_of_node(start_node_info) + ","
-    #                      + ChordUtil.gen_debug_str_of_node(cur_node_info))
-    #     print("", flush=True, end="")
-    #     raise Exception("SUCCESSOR_CHAIN_IS_NOT_CONSTRUCTED_COLLECTLY")
+    # 2ノード目が参加して以降をチェック対象とする
+    # successorを辿って最初のノードに戻ってきているはずだが、そうなっていない場合は successorの
+    # チェーン構造が正しく構成されていないことを意味するためエラーとして終了する
+    if all_node_num >=2 and cur_node_info.node_id != start_node_info.node_id:
+        ChordUtil.dprint("check_nodes_connectivity_succ_err,chain does not includes all node. all_node_num = "
+                         + str(all_node_num) + ","
+                         + ChordUtil.gen_debug_str_of_node(start_node_info) + ","
+                         + ChordUtil.gen_debug_str_of_node(cur_node_info))
+        # raise exception("SUCCESSOR_CHAIN_IS_NOT_CONSTRUCTED_COLLECTLY")
+    else:
+        ChordUtil.dprint("check_nodes_connectivity_succ_success,chain includes all node. all_node_num = "
+                         + str(all_node_num) + ","
+                         + ChordUtil.gen_debug_str_of_node(start_node_info) + ","
+                         + ChordUtil.gen_debug_str_of_node(cur_node_info))
 
     # 続いてpredecessor方向に辿る
     counter = 0
@@ -76,7 +80,7 @@ def check_nodes_connectivity():
             cur_node_info = ChordUtil.get_node_by_address(cur_node_info.address_str).node_info.predecessor_info
         except NodeIsDownedExceptiopn:
             print("")
-            ChordUtil.dprint("check_nodes_connectivity__pred, NODE_IS_DOWNED")
+            ChordUtil.dprint("check_nodes_connectivity__pred,NODE_IS_DOWNED")
             return
 
         # 2ノード目から本来チェック可能であるべきだが、stabilize処理の実行タイミングの都合で
@@ -93,18 +97,22 @@ def check_nodes_connectivity():
         counter += 1
     print("")
 
-    # # 2ノード目から本来チェック可能であるべきだが、stabilize処理の実行タイミングの都合で
-    # # 2ノード目がjoinした後、いくらかpredecessorがNoneの状態が生じ、そのタイミングで本チェックが走る場合が
-    # # あり得るため、余裕を持たせて5ノード目以降からチェックする
-    # # successorを辿って最初のノードに戻ってきているはずだが、そうなっていない場合は successorの
-    # # チェーン構造が正しく構成されていないことを意味するためエラーとして終了する
-    # if all_node_num >=5 and cur_node_info.node_id != start_node_info.node_id:
-    #     ChordUtil.dprint("check_nodes_connectivity_succ_err,chain does not include all node. all_node_num = "
-    #                      + str(all_node_num) + ","
-    #                      + ChordUtil.gen_debug_str_of_node(start_node_info) + ","
-    #                      + ChordUtil.gen_debug_str_of_node(cur_node_info)
-    #                      , flush=True)
-    #     raise Exception("PREDECESSOR_CHAIN_IS_NOT_CONSTRUCTED_COLLECTLY")
+    # 2ノード目から本来チェック可能であるべきだが、stabilize処理の実行タイミングの都合で
+    # 2ノード目がjoinした後、いくらかpredecessorがNoneの状態が生じ、そのタイミングで本チェックが走る場合が
+    # あり得るため、余裕を持たせて5ノード目以降からチェックする
+    # successorを辿って最初のノードに戻ってきているはずだが、そうなっていない場合は successorの
+    # チェーン構造が正しく構成されていないことを意味するためエラーとして終了する
+    if all_node_num >=5 and cur_node_info.node_id != start_node_info.node_id:
+        ChordUtil.dprint("check_nodes_connectivity_pred_err,chain does not includes all node. all_node_num = "
+                         + str(all_node_num) + ","
+                         + ChordUtil.gen_debug_str_of_node(start_node_info) + ","
+                         + ChordUtil.gen_debug_str_of_node(cur_node_info))
+        # raise Exception("PREDECESSOR_CHAIN_IS_NOT_CONSTRUCTED_COLLECTLY")
+    else:
+        ChordUtil.dprint("check_nodes_connectivity_pred_success,chain includes all node. all_node_num = "
+                         + str(all_node_num) + ","
+                         + ChordUtil.gen_debug_str_of_node(start_node_info) + ","
+                         + ChordUtil.gen_debug_str_of_node(cur_node_info))
 
 # ランダムに仲介ノードを選択し、そのノードに仲介してもらう形でネットワークに参加させる
 def add_new_node():

--- a/chord_sim/chord_sim.py
+++ b/chord_sim/chord_sim.py
@@ -368,11 +368,11 @@ def main():
     data_put_th_handle = threading.Thread(target=data_put_th, daemon=True)
     data_put_th_handle.start()
 
-    data_get_th_handle = threading.Thread(target=data_get_th, daemon=True)
-    data_get_th_handle.start()
+    # data_get_th_handle = threading.Thread(target=data_get_th, daemon=True)
+    # data_get_th_handle.start()
 
-    # node_kill_th_handle = threading.Thread(target=node_kill_th, daemon=True)
-    # node_kill_th_handle.start()
+    node_kill_th_handle = threading.Thread(target=node_kill_th, daemon=True)
+    node_kill_th_handle.start()
 
     while True:
         time.sleep(1)

--- a/chord_sim/chord_sim.py
+++ b/chord_sim/chord_sim.py
@@ -111,11 +111,18 @@ def add_new_node():
     # ロックの取得
     gval.lock_of_all_data.acquire()
 
-    # TODO: 前回の呼び出しが失敗していた場合はリトライを行うよう実装する
+    if ChordNode.need_join_retry_node != None:
+        # 前回の呼び出しが失敗していた場合はリトライを行う
+        tyukai_node = ChordNode.need_join_retry_tyukai_node
+        new_node = ChordNode.need_join_retry_node
+        new_node.join(tyukai_node.node_info.address_str)
+    else:
+        tyukai_node = get_a_random_node()
+        new_node = ChordNode(tyukai_node.node_info.address_str)
 
-    tyukai_node = get_a_random_node()
-    new_node = ChordNode(tyukai_node.node_info.address_str)
-    gval.all_node_dict[new_node.node_info.address_str] = new_node
+    if ChordNode.need_join_retry_node == None:
+        # join処理(リトライ時以外はChordNodeクラスのコンストラクタ内で行われる)が成功していれば
+        gval.all_node_dict[new_node.node_info.address_str] = new_node
 
     # ロックの解放
     gval.lock_of_all_data.release()

--- a/chord_sim/chord_sim.py
+++ b/chord_sim/chord_sim.py
@@ -8,7 +8,7 @@ from typing import List, cast
 import modules.gval as gval
 from modules.node_info import NodeInfo
 from modules.chord_util import ChordUtil, KeyValue
-from modules.chord_node import ChordNode
+from modules.chord_node import ChordNode, NodeIsDownedExectiopn
 
 # ネットワークに存在するノードから1ノードをランダムに取得する
 # ChordNodeオブジェクトを返す
@@ -39,8 +39,14 @@ def check_nodes_connectivity():
         # 各ノードはsuccessorの情報を保持しているが、successorのsuccessorは保持しないようになって
         # いるため、単純にsuccessorのチェーンを辿ることはできないため、各ノードから最新の情報を
         # 得ることに対応する形とする
-        # TODO: 例外発生時はreturnしてしまって良い
-        cur_node_info = ChordUtil.get_node_by_address(cur_node_info.address_str).node_info.successor_info_list[0]
+
+        try:
+            cur_node_info = ChordUtil.get_node_by_address(cur_node_info.address_str).node_info.successor_info_list[0]
+        except NodeIsDownedExectiopn:
+            print("")
+            ChordUtil.dprint("check_nodes_connectivity__succ, NODE_IS_DOWNED")
+            return
+
         if cur_node_info == None:
             print("", flush=True, end="")
             raise Exception("no successor having node was detected!")
@@ -66,8 +72,12 @@ def check_nodes_connectivity():
     print(",", flush=True, end="")
     while counter < all_node_num:
         ChordUtil.print_no_lf(str(cur_node_info.born_id) + "," + ChordUtil.conv_id_to_ratio_str(cur_node_info.node_id) + " -> ")
-        # TODO: 例外発生時はreturnしてしまって良い
-        cur_node_info = ChordUtil.get_node_by_address(cur_node_info.address_str).node_info.predecessor_info
+        try:
+            cur_node_info = ChordUtil.get_node_by_address(cur_node_info.address_str).node_info.predecessor_info
+        except NodeIsDownedExectiopn:
+            print("")
+            ChordUtil.dprint("check_nodes_connectivity__pred, NODE_IS_DOWNED")
+            return
 
         # 2ノード目から本来チェック可能であるべきだが、stabilize処理の実行タイミングの都合で
         # 2ノード目がjoinした後、いくらかpredecessorがNoneの状態が生じ、そのタイミングで本チェックが走る場合が

--- a/chord_sim/modules/chord_node.py
+++ b/chord_sim/modules/chord_node.py
@@ -303,7 +303,7 @@ class ChordNode:
         successor : ChordNode
         successor_tmp : Optional[ChordNode] = None
         for idx in range(len(self.node_info.successor_info_list)):
-            if ChordUtil.is_node_alive(self.node_info.successor_info_list[idx]):
+            if ChordUtil.is_node_alive(self.node_info.successor_info_list[idx].address_str):
                 successor_tmp = ChordUtil.get_node_by_address(self.node_info.successor_info_list[idx].address_str)
                 break
         if successor_tmp != None:
@@ -365,6 +365,7 @@ class ChordNode:
 
                     # successor[0]の変更は行わず、ダウンしていたノードではなく自身をpredecessorとするよう(間接的に)要請する
                     successor.check_predecessor(self.node_info.node_id, self.node_info)
+                    return successor.node_info.get_partial_deepcopy()
             else:
                 # successor[0] の変更は不要であった
                 return successor.node_info.get_partial_deepcopy()

--- a/chord_sim/modules/chord_node.py
+++ b/chord_sim/modules/chord_node.py
@@ -400,7 +400,7 @@ class ChordNode:
         # 最初は自ノードを指定してそのsuccessor[0]を取得するところからスタートする
         cur_node : ChordNode = self
 
-        while len(self.node_info.successor_info_list) == gval.SUCCESSOR_LIST_NORMAL_LEN:
+        while len(updated_list) < gval.SUCCESSOR_LIST_NORMAL_LEN:
             cur_node_info : NodeInfo = cur_node.stabilize_successor_inner()
             ChordUtil.dprint("stabilize_successor_1," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
                              + ChordUtil.gen_debug_str_of_node(cur_node_info))
@@ -410,13 +410,21 @@ class ChordNode:
                 # ノード数を満たしていないが、successor_info_list の更新処理は終了する
                 ChordUtil.dprint("stabilize_successor_2," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
                                  + ChordUtil.gen_debug_str_of_node(cur_node_info))
+                if len(updated_list) == 0:
+                    # first node の場合の考慮
+                    # second node が 未joinの場合、successsor[0] がリストに存在しない状態となってしまうため
+                    # その場合のみ、update_list で self.node_info.successor_info_listを上書きせずにreturnする
+                    ChordUtil.dprint("stabilize_successor_2_5," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
+                                     + ChordUtil.gen_debug_str_of_node(cur_node_info))
+                    return
+
                 break
+
             updated_list.append(cur_node_info)
             # この呼び出しで例外は発生しない
             cur_node = ChordUtil.get_node_by_address(cur_node_info)
 
         self.node_info.successor_info_list = updated_list
-
         ChordUtil.dprint("stabilize_successor_3," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
                      + str(self.node_info.successor_info_list))
 
@@ -473,7 +481,7 @@ class ChordNode:
 
         n_dash = self
         # n_dash と n_dashのsuccessorの 間に id が位置するような n_dash を見つけたら、ループを終了し n_dash を return する
-        while not ChordUtil.exist_between_two_nodes_right_mawari(cast(NodeInfo,n_dash.node_info).node_id, cast(NodeInfo, n_dash.node_info.successor_info_list[0]).node_id, id):
+        while not ChordUtil.exist_between_two_nodes_right_mawari(n_dash.node_info.node_id, n_dash.node_info.successor_info_list[0].node_id, id):
             ChordUtil.dprint("find_predecessor_2," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
                              + ChordUtil.gen_debug_str_of_node(n_dash.node_info))
             n_dash_found = n_dash.closest_preceding_finger(id)

--- a/chord_sim/modules/chord_node.py
+++ b/chord_sim/modules/chord_node.py
@@ -300,6 +300,8 @@ class ChordNode:
     def stabilize_successor_inner(self) -> NodeInfo:
         # 本メソッド呼び出しでsuccessorとして扱うノードはsuccessorListの先頭から生きているもの
         # をサーチし、発見したノードとする.
+        ChordUtil.dprint("stabilize_successor_inner_0," + ChordUtil.gen_debug_str_of_node(self.node_info))
+
         successor : ChordNode
         successor_tmp : Optional[ChordNode] = None
         for idx in range(len(self.node_info.successor_info_list)):
@@ -313,12 +315,17 @@ class ChordNode:
             # 起きてはいけない状況なので例外を投げてプログラムを終了させる
             raise Exception("Maybe some parameters related to fault-tolerance of Chord network are not appropriate")
 
-        ChordUtil.dprint("stabilize_successor_first_one_1," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
+        # 生存が確認されたノードを successor[0] として設定する
+        self.node_info.successor_info_list[0] = successor.node_info.get_partial_deepcopy()
+
+        ChordUtil.dprint("stabilize_successor_inner_1," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
                          + ChordUtil.gen_debug_str_of_node(self.node_info.successor_info_list[0]))
 
         pred_id_of_successor = cast(NodeInfo, successor.node_info.predecessor_info).node_id
 
-        ChordUtil.dprint("stabilize_successor_first_one_1_5," + hex(pred_id_of_successor))
+        ChordUtil.dprint("stabilize_successor_inner_2," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
+                         + ChordUtil.gen_debug_str_of_node(self.node_info.successor_info_list[0]) + ","
+                         + str(pred_id_of_successor))
 
         # successorに認識している predecessor の情報をチェックさせて、適切なものに変更させたり、把握していない
         # 自身のsuccessor[0]になるべきノードの存在が判明した場合は 自身の successor[0]をそちらに張り替える.
@@ -326,8 +333,10 @@ class ChordNode:
         # https://www.slideshare.net/did2/chorddht
         if(pred_id_of_successor == self.node_info.node_id):
             # パターン1
-            # 特に訂正は不要なので処理を終了する
-            return successor.node_info.get_partial_deepcopy()
+            # 特に訂正は不要
+            ChordUtil.dprint("stabilize_successor_inner_3," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
+                             + ChordUtil.gen_debug_str_of_node(self.node_info.successor_info_list[0]) + ","
+                             + str(pred_id_of_successor))
         else:
             # 以下、パターン2およびパターン3に対応する処理
 
@@ -353,11 +362,9 @@ class ChordNode:
                     # ば情報を更新してもらう
                     new_successor.check_predecessor(self.node_info.node_id, self.node_info)
 
-                    ChordUtil.dprint("stabilize_successor_first_one_2," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
+                    ChordUtil.dprint("stabilize_successor_inner_4," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
                                      + ChordUtil.gen_debug_str_of_node(self.node_info.successor_info_list[0]) + ","
                                      + ChordUtil.gen_debug_str_of_node(new_successor.node_info))
-
-                    return new_successor.node_info.get_partial_deepcopy()
                 except NodeIsDownedExectiopn:
                     # 例外発生時は張り替えを中止する
                     #   - successorは変更しない
@@ -365,10 +372,11 @@ class ChordNode:
 
                     # successor[0]の変更は行わず、ダウンしていたノードではなく自身をpredecessorとするよう(間接的に)要請する
                     successor.check_predecessor(self.node_info.node_id, self.node_info)
-                    return successor.node_info.get_partial_deepcopy()
-            else:
-                # successor[0] の変更は不要であった
-                return successor.node_info.get_partial_deepcopy()
+                    ChordUtil.dprint("stabilize_successor_inner_5," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
+                                     + ChordUtil.gen_debug_str_of_node(self.node_info.successor_info_list[0]) + ","
+                                     + str(cast(NodeInfo, self.node_info.successor_info_list[0].predecessor_info).node_id))
+
+        return self.node_info.successor_info_list[0].get_partial_deepcopy()
 
 
     # successorListに関するstabilize処理を行う
@@ -394,16 +402,23 @@ class ChordNode:
 
         while len(self.node_info.successor_info_list) == gval.SUCCESSOR_LIST_NORMAL_LEN:
             cur_node_info : NodeInfo = cur_node.stabilize_successor_inner()
+            ChordUtil.dprint("stabilize_successor_1," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
+                             + ChordUtil.gen_debug_str_of_node(cur_node_info))
             if cur_node_info.node_id == self.node_info.node_id:
                 # Chordネットワークに (downしていない状態で) 存在するノード数が gval.SUCCESSOR_LIST_NORMAL_LEN
                 # より多くない場合 successorをたどっていった結果、自ノードにたどり着いてしまうため、その場合は規定の
                 # ノード数を満たしていないが、successor_info_list の更新処理は終了する
+                ChordUtil.dprint("stabilize_successor_2," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
+                                 + ChordUtil.gen_debug_str_of_node(cur_node_info))
                 break
             updated_list.append(cur_node_info)
             # この呼び出しで例外は発生しない
             cur_node = ChordUtil.get_node_by_address(cur_node_info)
 
         self.node_info.successor_info_list = updated_list
+
+        ChordUtil.dprint("stabilize_successor_3," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
+                     + str(self.node_info.successor_info_list))
 
     # FingerTableに関するstabilize処理を行う
     # 一回の呼び出しで1エントリを更新する

--- a/chord_sim/modules/chord_node.py
+++ b/chord_sim/modules/chord_node.py
@@ -257,13 +257,13 @@ class ChordNode:
         if ChordNode.need_getting_retry_data_id != -1:
             if got_value_str != ChordNode.QUERIED_DATA_NOT_FOUND_STR:
                 # リトライに成功した
-                ChordUtil.dprint("global_get_2_5,retry success")
+                ChordUtil.dprint("global_get_2_5,retry of global_get is succeeded")
                 # リトライは不要なためクリア
                 ChordNode.need_getting_retry_data_id = -1
                 ChordNode.need_getting_retry_node = None
             else:
                 # リトライに失敗した（何もしない）
-                ChordUtil.dprint("global_get_2_5,retry failed")
+                ChordUtil.dprint("global_get_2_5,retry of global_get is failed")
                 pass
 
         # 取得に失敗した場合はリトライに必要な情報をクラス変数に設定しておく
@@ -287,26 +287,6 @@ class ChordNode:
         ChordUtil.dprint("get," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
                          + ChordUtil.gen_debug_str_of_data(data_id) + "," + ret_value_str)
         return ret_value_str
-
-    # # some_id をChordネットワーク上で担当するノードを返す
-    # # Attention: ノード探索を行ったが見つかったノードがダウンしていたか何かでアクセス不能
-    # #            であった場合は NodeIsDownedException を raise する
-    # def search_node(self, some_id : int) -> 'ChordNode':
-    #     ChordUtil.dprint("search_node_0," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
-    #                      + ChordUtil.gen_debug_str_of_data(some_id))
-    #
-    #     found_node = self.find_successor(some_id)
-    #     if found_node == None:
-    #         ChordUtil.dprint("search_node_1," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
-    #                          + ChordUtil.gen_debug_str_of_data(some_id))
-    #         raise NodeIsDownedExceptiopn()
-    #
-    #     found_node = cast(ChordNode, found_node)
-    #     ChordUtil.dprint("search_node_2," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
-    #                      + ChordUtil.gen_debug_str_of_node(found_node.node_info) + ","
-    #                      + ChordUtil.gen_debug_str_of_data(some_id))
-    #
-    #     return found_node
 
     # TODO: Deleteの実装
     # def global_delete(self, key_str):

--- a/chord_sim/modules/chord_node.py
+++ b/chord_sim/modules/chord_node.py
@@ -446,8 +446,14 @@ class ChordNode:
                     # successor[0]の変更は行わず、ダウンしていたノードではなく自身をpredecessorとするよう(間接的に)要請する
                     successor.check_predecessor(self.node_info.node_id, self.node_info)
                     ChordUtil.dprint("stabilize_successor_inner_5," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
-                                     + ChordUtil.gen_debug_str_of_node(self.node_info.successor_info_list[0]) + ","
-                                     + str(cast(NodeInfo, self.node_info.successor_info_list[0].predecessor_info).node_id))
+                                     + ChordUtil.gen_debug_str_of_node(self.node_info.successor_info_list[0]))
+                except TargetNodeDoesNotExistException:
+                    # joinの中から呼び出された際に、successorを辿って行った結果、一周してjoin処理中のノードを get_node_by_addressしようと
+                    # した際に発生してしまうので、ここで対処する
+                    # join処理中のノードのpredecessor, sucessorはjoin処理の中で適切に設定されているはずなの特に処理は不要であり
+                    # 本メソッドは元々の successor[0] を返せばよい
+                    ChordUtil.dprint("stabilize_successor_inner_6," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
+                                     + ChordUtil.gen_debug_str_of_node(self.node_info.successor_info_list[0]))
 
         return self.node_info.successor_info_list[0].get_partial_deepcopy()
 

--- a/chord_sim/modules/chord_node.py
+++ b/chord_sim/modules/chord_node.py
@@ -65,8 +65,7 @@ class ChordNode:
             self.stored_data[str(key_value.data_id)] = key_value.value
 
         # finger_tableのインデックス0は必ずsuccessorになるはずなので、設定しておく
-        # self.node_info.finger_table[0] = self.node_info.successor_info_list[0].get_partial_deepcopy()
-        self.node_info.finger_table[0] = ChordUtil.get_deepcopy_of_successor_list(self.node_info.successor_info_list)
+        self.node_info.finger_table[0] = self.node_info.successor_info_list[0].get_partial_deepcopy()
 
         if tyukai_node.node_info.node_id == tyukai_node.node_info.successor_info_list[0].node_id:
             # secondノードの場合の考慮 (仲介ノードは必ずfirst node)
@@ -76,7 +75,7 @@ class ChordNode:
             tyukai_node.node_info.predecessor_info = self.node_info.get_partial_deepcopy()
             tyukai_node.node_info.successor_info_list[0] = self.node_info.get_partial_deepcopy()
             # fingerテーブルの0番エントリも強制的に設定する
-            tyukai_node.node_info.finger_table[0] = [self.node_info.get_partial_deepcopy()]
+            tyukai_node.node_info.finger_table[0] = self.node_info.get_partial_deepcopy()
         else:
             # 強制的に自身を既存のチェーンに挿入する
             # successorは predecessorの 情報を必ず持っていることを前提とする
@@ -451,7 +450,7 @@ class ChordNode:
         #       リトライさせたところで、途中で経由するノードのfinger_tableの情報にすぐにノードダウンの事実
         #       が反映されるかも怪しいし、finger_tableの各エントリを拡張した点を活用して、リトライを可能な限り
         #       避けるような設計にするのが良いのでは？
-        self.node_info.finger_table[idx] = ChordUtil.get_deepcopy_of_successor_list([found_node.node_info])
+        self.node_info.finger_table[idx] = found_node.node_info.get_partial_deepcopy()
 
         ChordUtil.dprint("stabilize_finger_table_3," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
                          + ChordUtil.gen_debug_str_of_node(found_node.node_info))
@@ -529,16 +528,16 @@ class ChordNode:
         # finger_tableはインデックスが小さい方から大きい方に、範囲が大きくなっていく
         # ように構成されているため、リバースしてインデックスの大きな方から小さい方へ
         # 順に見ていくようにする
-        for slist in reversed(self.node_info.finger_table):
+        for node_info in reversed(self.node_info.finger_table):
             # 埋まっていないエントリも存在し得る
-            if slist == None:
+            if node_info == None:
                 ChordUtil.dprint("closest_preceding_finger_0," + ChordUtil.gen_debug_str_of_node(self.node_info))
                 continue
 
-            casted_slist = cast(List[NodeInfo], slist)
+            casted_node_info = cast(NodeInfo, node_info)
 
             ChordUtil.dprint("closest_preceding_finger_1," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
-                  + ChordUtil.gen_debug_str_of_node(casted_slist[0]))
+                  + ChordUtil.gen_debug_str_of_node(casted_node_info))
 
             # テーブル内のエントリが保持しているノードのIDが自身のIDと探索対象のIDの間にあれば
             # それを返す
@@ -547,11 +546,11 @@ class ChordNode:
             #  可能性が高いということになる。そこで探索範囲を狭めていって、飛び越さない範囲で一番近いノードを
             #  見つけるという処理になっていると思われる）
             # #if self.node_info.node_id < entry.node_id and entry.node_id <= id:
-            if ChordUtil.exist_between_two_nodes_right_mawari(self.node_info.node_id, id, casted_slist[0].node_id):
+            if ChordUtil.exist_between_two_nodes_right_mawari(self.node_info.node_id, id, casted_node_info.node_id):
                 ChordUtil.dprint("closest_preceding_finger_2," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
-                                 + ChordUtil.gen_debug_str_of_node(casted_slist[0]))
+                                 + ChordUtil.gen_debug_str_of_node(casted_node_info))
                 # TODO: 例外発生時はcontinueしてしまってよい
-                return ChordUtil.get_node_by_address(casted_slist[0].address_str)
+                return ChordUtil.get_node_by_address(casted_node_info.address_str)
 
         ChordUtil.dprint("closest_preceding_finger_3")
 

--- a/chord_sim/modules/chord_node.py
+++ b/chord_sim/modules/chord_node.py
@@ -142,7 +142,7 @@ class ChordNode:
         # TODO: predecessorが非Noneであれば、当該predecessorからレプリケーションデータの受け取りを行う
 
         # 自ノードの情報、仲介ノードの情報、successorとして設定したノードの情報
-        ChordUtil.dprint("join," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
+        ChordUtil.dprint("join_5," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
                          + ChordUtil.gen_debug_str_of_node(tyukai_node.node_info) + ","
                          + ChordUtil.gen_debug_str_of_node(self.node_info.successor_info_list[0]))
 
@@ -376,11 +376,18 @@ class ChordNode:
                 if ChordUtil.is_node_alive(self.node_info.successor_info_list[idx].address_str):
                     successor_tmp = ChordUtil.get_node_by_address(self.node_info.successor_info_list[idx].address_str)
                     break
+                else:
+                    ChordUtil.dprint("stabilize_successor_inner_1,SUCCESSOR_IS_DOWNED,"
+                                     + ChordUtil.gen_debug_str_of_node(self.node_info) + ","
+                                     + ChordUtil.gen_debug_str_of_node(self.node_info.successor_info_list[idx]))
             except TargetNodeDoesNotExistException:
                 # joinの中から呼び出された際に、successorを辿って行った結果、一周してjoin処理中のノードを get_node_by_addressしようと
                 # した際に発生してしまうので、ここで対処する
                 # join処理中のノードのpredecessor, sucessorはjoin処理の中で適切に設定されているはずなので、後続の処理を行わず successor[0]を返す
                 return self.node_info.successor_info_list[0].get_partial_deepcopy()
+
+        # TODO: DEBUG時のみ必要なのであとで消す
+        print("flush", flush=True)
 
         if successor_tmp != None:
             successor = cast(ChordNode, successor_tmp)

--- a/chord_sim/modules/chord_node.py
+++ b/chord_sim/modules/chord_node.py
@@ -422,7 +422,7 @@ class ChordNode:
 
             updated_list.append(cur_node_info)
             # この呼び出しで例外は発生しない
-            cur_node = ChordUtil.get_node_by_address(cur_node_info)
+            cur_node = ChordUtil.get_node_by_address(cur_node_info.address_str)
 
         self.node_info.successor_info_list = updated_list
         ChordUtil.dprint("stabilize_successor_3," + ChordUtil.gen_debug_str_of_node(self.node_info) + ","

--- a/chord_sim/modules/chord_node.py
+++ b/chord_sim/modules/chord_node.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional, cast
 
 import modules.gval as gval
 from .node_info import NodeInfo
-from .chord_util import ChordUtil, KeyValue, NodeIsDownedExceptiopn, AppropriateNodeNotFoundException, TargetNodeIsNotExistException
+from .chord_util import ChordUtil, KeyValue, NodeIsDownedExceptiopn, AppropriateNodeNotFoundException, TargetNodeDoesNotExistException
 
 class ChordNode:
     QUERIED_DATA_NOT_FOUND_STR = "QUERIED_DATA_WAS_NOT_FOUND"
@@ -375,7 +375,7 @@ class ChordNode:
                 if ChordUtil.is_node_alive(self.node_info.successor_info_list[idx].address_str):
                     successor_tmp = ChordUtil.get_node_by_address(self.node_info.successor_info_list[idx].address_str)
                     break
-            except TargetNodeIsNotExistException:
+            except TargetNodeDoesNotExistException:
                 # joinの中から呼び出された際に、successorを辿って行った結果、一周してjoin処理中のノードを get_node_by_addressしようと
                 # した際に発生してしまうので、ここで対処する
                 # join処理中のノードのpredecessor, sucessorはjoin処理の中で適切に設定されているはずなので、後続の処理を行わず successor[0]を返す

--- a/chord_sim/modules/chord_util.py
+++ b/chord_sim/modules/chord_util.py
@@ -196,10 +196,10 @@ class KeyValue:
 class NodeIsDownedExceptiopn(Exception):
 
     def __init__(self):
-        super(NodeIsDownedExceptiopn, self).__init__("Accessed Node seems to be downed.")
+        super(NodeIsDownedExceptiopn, self).__init__("Accessed node seems to be downed.")
 
-class FindNodeFailedException(Exception):
+class AppropriateNodeNotFoundException(Exception):
 
     def __init__(self):
-        super(FindNodeFailedException, self).__init__("Node finding is failed.")
+        super(AppropriateNodeNotFoundException, self).__init__("Appropriate node is not found.")
 

--- a/chord_sim/modules/chord_util.py
+++ b/chord_sim/modules/chord_util.py
@@ -177,6 +177,7 @@ class ChordUtil:
 
         return ret_val
 
+    # Attention: TargetNodeDoesNotExistException を raiseする場合がある
     @classmethod
     def is_node_alive(cls, address : str) -> bool:
         try:

--- a/chord_sim/modules/chord_util.py
+++ b/chord_sim/modules/chord_util.py
@@ -185,13 +185,13 @@ class ChordUtil:
 
         return True
 
-    @classmethod
-    def get_deepcopy_of_successor_list(cls, slist : List['NodeInfo']) -> List['NodeInfo']:
-        ret_list : List['NodeInfo'] = []
-        for node_info in slist:
-            ret_list.append(node_info.get_partial_deepcopy())
-
-        return slist
+    # @classmethod
+    # def get_deepcopy_of_successor_list(cls, slist : List['NodeInfo']) -> List['NodeInfo']:
+    #     ret_list : List['NodeInfo'] = []
+    #     for node_info in slist:
+    #         ret_list.append(node_info.get_partial_deepcopy())
+    #
+    #     return slist
 
 # all_data_listグローバル変数に格納される形式としてのみ用いる
 class KeyValue:

--- a/chord_sim/modules/chord_util.py
+++ b/chord_sim/modules/chord_util.py
@@ -177,6 +177,15 @@ class ChordUtil:
             raise NodeIsDownedExectiopn()
 
     @classmethod
+    def is_node_alive(cls, address : str) -> bool:
+        try:
+            ChordUtil.get_node_by_address(address)
+        except NodeIsDownedExectiopn:
+            return False
+
+        return True
+
+    @classmethod
     def get_deepcopy_of_successor_list(cls, slist : List['NodeInfo']) -> List['NodeInfo']:
         ret_list : List['NodeInfo'] = []
         for node_info in slist:

--- a/chord_sim/modules/chord_util.py
+++ b/chord_sim/modules/chord_util.py
@@ -184,8 +184,10 @@ class ChordUtil:
         except KeyError:
             # join処理の途中で構築中のノード情報をチェックしてしまいにいった場合に発生する
             raise TargetNodeDoesNotExistException()
+        except NodeIsDownedExceptiopn:
+            return False
 
-        return node_obj.is_alive
+        return True
 
 # all_data_listグローバル変数に格納される形式としてのみ用いる
 class KeyValue:

--- a/chord_sim/modules/chord_util.py
+++ b/chord_sim/modules/chord_util.py
@@ -179,7 +179,12 @@ class ChordUtil:
 
     @classmethod
     def is_node_alive(cls, address : str) -> bool:
-        node_obj = ChordUtil.get_node_by_address(address)
+        try:
+            node_obj = ChordUtil.get_node_by_address(address)
+        except KeyError:
+            # join処理の途中で構築中のノード情報をチェックしてしまいにいった場合に発生する
+            raise TargetNodeIsNotExistException()
+
         return node_obj.is_alive
 
 # all_data_listグローバル変数に格納される形式としてのみ用いる
@@ -203,3 +208,9 @@ class AppropriateNodeNotFoundException(Exception):
     def __init__(self):
         super(AppropriateNodeNotFoundException, self).__init__("Appropriate node is not found.")
 
+# 通常、join時に all_node_dictにノードオブジェクトが登録される前に
+# ノードのアドレスによる取得を試みた場合のみしか発生しない
+class TargetNodeIsNotExistException(Exception):
+
+    def __init__(self):
+        super(TargetNodeIsNotExistException, self).__init__("Target node is not exist on kvs network yet.")

--- a/chord_sim/modules/chord_util.py
+++ b/chord_sim/modules/chord_util.py
@@ -167,31 +167,20 @@ class ChordUtil:
         return hex(data_id) + "," + ChordUtil.conv_id_to_ratio_str(data_id)
 
     # Attention: 取得しようとしたノードが all_node_dict に存在しないことは、そのノードが 離脱（ダウンしている状態も含）
-    #            したことを意味するため、対応する NodeIsDownedException 例外を raise する
+    #            したことを意味するため、当該状態に対応する NodeIsDownedException 例外を raise する
     @classmethod
     def get_node_by_address(cls, address : str) -> 'ChordNode':
-        try:
-            ret_val = gval.all_node_dict[address]
-            return ret_val
-        except KeyError:
-            raise NodeIsDownedExectiopn()
+        ret_val = gval.all_node_dict[address]
+        if ret_val.is_alive == False:
+            ChordUtil.dprint("get_node_by_address_1,NODE_IS_DOWNED," + ChordUtil.gen_debug_str_of_node(ret_val.node_info))
+            raise NodeIsDownedExceptiopn()
+
+        return ret_val
 
     @classmethod
     def is_node_alive(cls, address : str) -> bool:
-        try:
-            ChordUtil.get_node_by_address(address)
-        except NodeIsDownedExectiopn:
-            return False
-
-        return True
-
-    # @classmethod
-    # def get_deepcopy_of_successor_list(cls, slist : List['NodeInfo']) -> List['NodeInfo']:
-    #     ret_list : List['NodeInfo'] = []
-    #     for node_info in slist:
-    #         ret_list.append(node_info.get_partial_deepcopy())
-    #
-    #     return slist
+        node_obj = ChordUtil.get_node_by_address(address)
+        return node_obj.is_alive
 
 # all_data_listグローバル変数に格納される形式としてのみ用いる
 class KeyValue:
@@ -204,8 +193,13 @@ class KeyValue:
         else:
             self.data_id : int = ChordUtil.hash_str_to_int(key)
 
-class NodeIsDownedExectiopn(Exception):
+class NodeIsDownedExceptiopn(Exception):
 
     def __init__(self):
-        super(NodeIsDownedExectiopn, self).__init__("Accessed Node seems to be downed.")
+        super(NodeIsDownedExceptiopn, self).__init__("Accessed Node seems to be downed.")
+
+class FindNodeFailedException(Exception):
+
+    def __init__(self):
+        super(FindNodeFailedException, self).__init__("Node finding is failed.")
 

--- a/chord_sim/modules/chord_util.py
+++ b/chord_sim/modules/chord_util.py
@@ -183,7 +183,7 @@ class ChordUtil:
             node_obj = ChordUtil.get_node_by_address(address)
         except KeyError:
             # join処理の途中で構築中のノード情報をチェックしてしまいにいった場合に発生する
-            raise TargetNodeIsNotExistException()
+            raise TargetNodeDoesNotExistException()
 
         return node_obj.is_alive
 
@@ -210,7 +210,7 @@ class AppropriateNodeNotFoundException(Exception):
 
 # 通常、join時に all_node_dictにノードオブジェクトが登録される前に
 # ノードのアドレスによる取得を試みた場合のみしか発生しない
-class TargetNodeIsNotExistException(Exception):
+class TargetNodeDoesNotExistException(Exception):
 
     def __init__(self):
-        super(TargetNodeIsNotExistException, self).__init__("Target node is not exist on kvs network yet.")
+        super(TargetNodeDoesNotExistException, self).__init__("Target node is not exist on kvs network yet.")

--- a/chord_sim/modules/gval.py
+++ b/chord_sim/modules/gval.py
@@ -15,6 +15,9 @@ JOIN_INTERVAL_SEC = 0.7 # 0.5 # 1
 PUT_INTERVAL_SEC = 0.5 # 1
 GET_INTERVAL_SEC = 0.5 # 1
 
+# ノード増加の勢いは 係数-1/係数 となる
+NODE_KILL_INTERVAL_SEC = JOIN_INTERVAL_SEC * 3
+
 # 全ノードがstabilize_successorを実行することを1バッチとした際に
 # stabilize処理担当のスレッドにより呼び出されるstabilize処理を行わせる
 # メソッドの一回の呼び出しで何バッチが実行されるか

--- a/chord_sim/modules/gval.py
+++ b/chord_sim/modules/gval.py
@@ -11,9 +11,9 @@ if TYPE_CHECKING:
 ID_SPACE_BITS = 30 # 160 <- sha1での本来の値
 ID_SPACE_RANGE = 2**ID_SPACE_BITS # 0を含めての数である点に注意
 
-JOIN_INTERVAL_SEC = 1 #0.5
-PUT_INTERVAL_SEC = 1 #0.5
-GET_INTERVAL_SEC = 1 #0.5
+JOIN_INTERVAL_SEC = 0.7 # 0.5 # 1
+PUT_INTERVAL_SEC = 0.5 # 1
+GET_INTERVAL_SEC = 0.5 # 1
 
 # 全ノードがstabilize_successorを実行することを1バッチとした際に
 # stabilize処理担当のスレッドにより呼び出されるstabilize処理を行わせる

--- a/chord_sim/modules/gval.py
+++ b/chord_sim/modules/gval.py
@@ -11,9 +11,9 @@ if TYPE_CHECKING:
 ID_SPACE_BITS = 30 # 160 <- sha1での本来の値
 ID_SPACE_RANGE = 2**ID_SPACE_BITS # 0を含めての数である点に注意
 
-JOIN_INTERVAL_SEC = 0.5
-PUT_INTERVAL_SEC = 0.5
-GET_INTERVAL_SEC = 0.5
+JOIN_INTERVAL_SEC = 1 #0.5
+PUT_INTERVAL_SEC = 1 #0.5
+GET_INTERVAL_SEC = 1 #0.5
 
 # 全ノードがstabilize_successorを実行することを1バッチとした際に
 # stabilize処理担当のスレッドにより呼び出されるstabilize処理を行わせる

--- a/chord_sim/modules/node_info.py
+++ b/chord_sim/modules/node_info.py
@@ -33,6 +33,7 @@ class NodeInfo:
         # sha1で生成されるハッシュ値は160bit符号無し整数であるため要素数は160となる
 
         # TODO: 現在は ID_SPACE_BITS が検証時の実行時間の短縮のため30となっている
+        # TODO: 各エントリは複数ノードの情報を保持できるようにしてあるが、単ノードで良いのかもしれない
         self.finger_table: List[Optional[List[NodeInfo]]] = [None] * gval.ID_SPACE_BITS
 
     # 単純にdeepcopyするとチェーン構造になっているものが全てコピーされてしまう

--- a/chord_sim/modules/node_info.py
+++ b/chord_sim/modules/node_info.py
@@ -33,8 +33,7 @@ class NodeInfo:
         # sha1で生成されるハッシュ値は160bit符号無し整数であるため要素数は160となる
 
         # TODO: 現在は ID_SPACE_BITS が検証時の実行時間の短縮のため30となっている
-        # TODO: 各エントリは複数ノードの情報を保持できるようにしてあるが、単ノードで良いのかもしれない
-        self.finger_table: List[Optional[List[NodeInfo]]] = [None] * gval.ID_SPACE_BITS
+        self.finger_table: List[Optional[NodeInfo]] = [None] * gval.ID_SPACE_BITS
 
     # 単純にdeepcopyするとチェーン構造になっているものが全てコピーされてしまう
     # ため、そこの考慮を行い、また、finger_tableはコピーしない形での deepcopy


### PR DESCRIPTION
掲題の通り。
join, put, の操作および、それらの処理の中を中心に発生するルーティング処理は、ノードダウンが一定時間間隔で発生する状況でもリトライなどを行うことで、耐性を担保できることが確認されている。
また、stabilizeの処理もノードダウンを想定したものに修正することで、ノードダウンが発生しても、ネットワーク構造を正常に維持できることが確認されている。

ただし、getの処理に関してはまだ対応ができていない（putで格納されるデータの複数ノードへのレプリケーション、および、その上で、主担当のノードがダウンした場合の連携処理が実装されていない）。